### PR TITLE
Nodes infront/behind other nodes correctly

### DIFF
--- a/GodotGame/UIs/LeaveVillage.tscn
+++ b/GodotGame/UIs/LeaveVillage.tscn
@@ -38,11 +38,13 @@ size_flags_horizontal = 4
 [node name="Yes" type="Button" parent="ColorRect/MarginContainer/VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
+focus_neighbor_left = NodePath("../No")
 text = "Yes"
 
 [node name="No" type="Button" parent="ColorRect/MarginContainer/VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
+focus_neighbor_right = NodePath("../Yes")
 text = "No
 "
 

--- a/GodotGame/World Scene/World.gd
+++ b/GodotGame/World Scene/World.gd
@@ -34,6 +34,7 @@ func increase_day(amount):
 
 func _on_open_leave_menu():
 	$UI/LeaveVillage.show()
+	$UI/LeaveVillage/ColorRect/MarginContainer/VBoxContainer/HBoxContainer/Yes.grab_focus()
 
 #**********TEST BUTTONS***********#
 func _on_test_inc_1():

--- a/GodotGame/World Scene/World.tscn
+++ b/GodotGame/World Scene/World.tscn
@@ -549,6 +549,7 @@ sources/1 = SubResource("TileSetAtlasSource_jvext")
 sources/2 = SubResource("TileSetAtlasSource_r1ptl")
 
 [node name="World" type="Node2D"]
+y_sort_enabled = true
 script = ExtResource("1_1qbtd")
 
 [node name="GrassTiles" type="TileMap" parent="."]
@@ -616,10 +617,14 @@ pivot_offset = Vector2(58, -28)
 [node name="NPC" parent="." instance=ExtResource("10_6867b")]
 position = Vector2(318, 106)
 
+[node name="DialogueBox" parent="NPC" index="2"]
+z_index = 1
+
 [node name="NPC2" parent="." instance=ExtResource("10_6867b")]
 position = Vector2(977, 101)
 
 [node name="DialogueBox" parent="NPC2" index="2"]
+z_index = 1
 dialogue_data = ExtResource("11_611hs")
 start_id = "NPC2"
 


### PR DESCRIPTION

- When the player is over an NPC or other object, it should automatically be in-front or behind the player as seen in the screenshots.
<details>
<summary>Screenshots</summary>
Before:

![2024-02-22 15_57_04-GodotProject (DEBUG)](https://github.com/FrancisTR/Godot-TBD/assets/57016218/016306c8-3acb-4bb5-91c5-92ab68fc9ab3)

After:

![2024-02-22 16_30_00-GodotProject (DEBUG)](https://github.com/FrancisTR/Godot-TBD/assets/57016218/55890f1a-ed86-44f5-8d31-3a7cfe47ca84)

</details>

- Slighty improved keyboard support.