### PR TITLE
Complete options menu

### DIFF
--- a/GodotGame/Main Menu Scene/MainMenu.gd
+++ b/GodotGame/Main Menu Scene/MainMenu.gd
@@ -2,8 +2,8 @@ extends Control # Originally Node2D; probably will conflict
 
 
 # Called when the node enters the scene tree for the first time.
-#func _ready():
-	#$VBoxContainer/StartButton.grab_focus()
+func _ready():
+	$StartButton.grab_focus()
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/GodotGame/Main Menu Scene/Options.tscn
+++ b/GodotGame/Main Menu Scene/Options.tscn
@@ -37,9 +37,9 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -189.0
-offset_top = 51.0
+offset_top = 102.0
 offset_right = 189.0
-offset_bottom = 142.0
+offset_bottom = 193.0
 grow_horizontal = 2
 grow_vertical = 2
 focus_neighbor_bottom = NodePath("../../BackButton")
@@ -127,7 +127,6 @@ focus_previous = NodePath("../TextureRect/OkayButton")
 text = "Back"
 
 [node name="RemapContainer" type="HBoxContainer" parent="BackButton"]
-layout_mode = 1
 offset_left = 336.0
 offset_top = 192.0
 offset_right = 813.0
@@ -219,6 +218,54 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_font_sizes/normal_font_size = 35
 text = "SFX Volume:"
+
+[node name="MusicSlider" type="HSlider" parent="."]
+offset_left = 337.0
+offset_top = 369.0
+offset_right = 813.0
+offset_bottom = 385.0
+focus_neighbor_top = NodePath("../BackButton/RemapContainer/LeftMapButton")
+focus_neighbor_bottom = NodePath("../TextureRect/OkayButton")
+focus_next = NodePath("../TextureRect/OkayButton")
+focus_previous = NodePath("../BackButton/RemapContainer/LeftMapButton")
+value = 100.0
+script = ExtResource("2_jtr8r")
+bus_name = "music"
+
+[node name="SFXVolumeValueLabel" type="RichTextLabel" parent="MusicSlider"]
+texture_filter = 1
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = 249.0
+offset_top = -29.0
+offset_right = 464.0
+offset_bottom = 26.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/normal_font_size = 35
+text = "100
+"
+
+[node name="SFXVolumeLabel" type="RichTextLabel" parent="MusicSlider"]
+texture_filter = 1
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -493.0
+offset_top = -29.0
+offset_right = -240.0
+offset_bottom = 26.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/normal_font_size = 35
+text = "Music Volume:"
 
 [connection signal="pressed" from="TextureRect/OkayButton" to="." method="_on_button_pressed"]
 [connection signal="pressed" from="BackButton" to="." method="_on_back_button_pressed"]

--- a/GodotGame/Main Menu Scene/Options.tscn
+++ b/GodotGame/Main Menu Scene/Options.tscn
@@ -44,7 +44,7 @@ grow_horizontal = 2
 grow_vertical = 2
 focus_neighbor_bottom = NodePath("../../BackButton")
 focus_next = NodePath("../../BackButton")
-focus_previous = NodePath("../../SfxSlider")
+focus_previous = NodePath("../../MusicSlider")
 theme_override_font_sizes/font_size = 35
 text = "Okay"
 
@@ -80,8 +80,8 @@ offset_bottom = -155.0
 grow_horizontal = 2
 grow_vertical = 2
 focus_neighbor_top = NodePath("../../BackButton")
-focus_neighbor_bottom = NodePath("../../BackButton/RemapContainer/LeftMapButton")
-focus_next = NodePath("../../BackButton/RemapContainer/LeftMapButton")
+focus_neighbor_bottom = NodePath("../../RemapContainer/LeftMapButton")
+focus_next = NodePath("../../RemapContainer/LeftMapButton")
 focus_previous = NodePath("../../BackButton")
 placeholder_text = "Enter username"
 clear_button_enabled = true
@@ -126,26 +126,26 @@ focus_next = NodePath("../TextureRect/LineEdit")
 focus_previous = NodePath("../TextureRect/OkayButton")
 text = "Back"
 
-[node name="RemapContainer" type="HBoxContainer" parent="BackButton"]
+[node name="RemapContainer" type="HBoxContainer" parent="."]
 offset_left = 336.0
 offset_top = 192.0
 offset_right = 813.0
 offset_bottom = 261.0
 
-[node name="LeftMapButton" type="Button" parent="BackButton/RemapContainer"]
+[node name="LeftMapButton" type="Button" parent="RemapContainer"]
 texture_filter = 1
 layout_mode = 2
 focus_neighbor_left = NodePath("../RightMapButton")
-focus_neighbor_top = NodePath("../../../TextureRect/LineEdit")
+focus_neighbor_top = NodePath("../../TextureRect/LineEdit")
 focus_neighbor_right = NodePath("../UpMapButton")
 focus_next = NodePath("../UpMapButton")
-focus_previous = NodePath("../../../TextureRect/LineEdit")
+focus_previous = NodePath("../../TextureRect/LineEdit")
 theme_override_font_sizes/font_size = 35
 text = " A "
 script = ExtResource("3_sdtpu")
 action = "Left"
 
-[node name="UpMapButton" type="Button" parent="BackButton/RemapContainer"]
+[node name="UpMapButton" type="Button" parent="RemapContainer"]
 texture_filter = 1
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
@@ -153,7 +153,7 @@ text = " W "
 script = ExtResource("3_sdtpu")
 action = "Up"
 
-[node name="DownMapButton" type="Button" parent="BackButton/RemapContainer"]
+[node name="DownMapButton" type="Button" parent="RemapContainer"]
 texture_filter = 1
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
@@ -161,10 +161,10 @@ text = " S "
 script = ExtResource("3_sdtpu")
 action = "Down"
 
-[node name="RightMapButton" type="Button" parent="BackButton/RemapContainer"]
+[node name="RightMapButton" type="Button" parent="RemapContainer"]
 texture_filter = 1
 layout_mode = 2
-focus_next = NodePath("../../../SfxSlider")
+focus_next = NodePath("../../SfxSlider")
 focus_previous = NodePath("../DownMapButton")
 theme_override_font_sizes/font_size = 35
 text = " D "
@@ -176,10 +176,10 @@ offset_left = 337.0
 offset_top = 318.0
 offset_right = 813.0
 offset_bottom = 334.0
-focus_neighbor_top = NodePath("../BackButton/RemapContainer/LeftMapButton")
-focus_neighbor_bottom = NodePath("../TextureRect/OkayButton")
-focus_next = NodePath("../TextureRect/OkayButton")
-focus_previous = NodePath("../BackButton/RemapContainer/LeftMapButton")
+focus_neighbor_top = NodePath("../RemapContainer/LeftMapButton")
+focus_neighbor_bottom = NodePath("../MusicSlider")
+focus_next = NodePath("../MusicSlider")
+focus_previous = NodePath("../RemapContainer/LeftMapButton")
 value = 100.0
 script = ExtResource("2_jtr8r")
 bus_name = "sfx"
@@ -224,10 +224,10 @@ offset_left = 337.0
 offset_top = 369.0
 offset_right = 813.0
 offset_bottom = 385.0
-focus_neighbor_top = NodePath("../BackButton/RemapContainer/LeftMapButton")
+focus_neighbor_top = NodePath("../SfxSlider")
 focus_neighbor_bottom = NodePath("../TextureRect/OkayButton")
 focus_next = NodePath("../TextureRect/OkayButton")
-focus_previous = NodePath("../BackButton/RemapContainer/LeftMapButton")
+focus_previous = NodePath("../SfxSlider")
 value = 100.0
 script = ExtResource("2_jtr8r")
 bus_name = "music"

--- a/GodotGame/Main Menu Scene/Options.tscn
+++ b/GodotGame/Main Menu Scene/Options.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://bq46ncf7jihje"]
+[gd_scene load_steps=4 format=3 uid="uid://bq46ncf7jihje"]
 
 [ext_resource type="Script" path="res://Main Menu Scene/Options.gd" id="1_pejof"]
 [ext_resource type="Script" path="res://Main Menu Scene/VolumeOptions.gd" id="2_jtr8r"]
+[ext_resource type="Script" path="res://Main Menu Scene/Remapper.gd" id="3_sdtpu"]
 
 [node name="EnterOptions" type="CanvasLayer"]
 script = ExtResource("1_pejof")
@@ -79,8 +80,8 @@ offset_bottom = -155.0
 grow_horizontal = 2
 grow_vertical = 2
 focus_neighbor_top = NodePath("../../BackButton")
-focus_neighbor_bottom = NodePath("../../BackButton/HBoxContainer/LeftKeyButton")
-focus_next = NodePath("../../BackButton/HBoxContainer/LeftKeyButton")
+focus_neighbor_bottom = NodePath("../../BackButton/RemapContainer/LeftMapButton")
+focus_next = NodePath("../../BackButton/RemapContainer/LeftMapButton")
 focus_previous = NodePath("../../BackButton")
 placeholder_text = "Enter username"
 clear_button_enabled = true
@@ -125,60 +126,61 @@ focus_next = NodePath("../TextureRect/LineEdit")
 focus_previous = NodePath("../TextureRect/OkayButton")
 text = "Back"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="BackButton"]
+[node name="RemapContainer" type="HBoxContainer" parent="BackButton"]
 layout_mode = 1
 offset_left = 336.0
 offset_top = 192.0
 offset_right = 813.0
 offset_bottom = 261.0
 
-[node name="LeftKeyButton" type="Button" parent="BackButton/HBoxContainer"]
+[node name="LeftMapButton" type="Button" parent="BackButton/RemapContainer"]
 texture_filter = 1
 layout_mode = 2
-focus_neighbor_left = NodePath("../RightKeyButton")
+focus_neighbor_left = NodePath("../RightMapButton")
 focus_neighbor_top = NodePath("../../../TextureRect/LineEdit")
-focus_neighbor_right = NodePath("../TopKeyButton")
-focus_next = NodePath("../TopKeyButton")
+focus_neighbor_right = NodePath("../UpMapButton")
+focus_next = NodePath("../UpMapButton")
 focus_previous = NodePath("../../../TextureRect/LineEdit")
 theme_override_font_sizes/font_size = 35
-text = "A"
+text = " A "
+script = ExtResource("3_sdtpu")
+action = "Left"
 
-[node name="TopKeyButton" type="Button" parent="BackButton/HBoxContainer"]
+[node name="UpMapButton" type="Button" parent="BackButton/RemapContainer"]
 texture_filter = 1
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
-text = "W"
+text = " W "
+script = ExtResource("3_sdtpu")
+action = "Up"
 
-[node name="BottomKeyButton" type="Button" parent="BackButton/HBoxContainer"]
+[node name="DownMapButton" type="Button" parent="BackButton/RemapContainer"]
 texture_filter = 1
 layout_mode = 2
 theme_override_font_sizes/font_size = 35
-text = "S"
+text = " S "
+script = ExtResource("3_sdtpu")
+action = "Down"
 
-[node name="RightKeyButton" type="Button" parent="BackButton/HBoxContainer"]
+[node name="RightMapButton" type="Button" parent="BackButton/RemapContainer"]
 texture_filter = 1
 layout_mode = 2
 focus_next = NodePath("../../../SfxSlider")
-focus_previous = NodePath("../BottomKeyButton")
+focus_previous = NodePath("../DownMapButton")
 theme_override_font_sizes/font_size = 35
-text = "D"
-
-[node name="TemporaryButton" type="Button" parent="BackButton/HBoxContainer"]
-texture_filter = 1
-layout_mode = 2
-theme_override_font_sizes/font_size = 35
-text = "Work in progress
-"
+text = " D "
+script = ExtResource("3_sdtpu")
+action = "Right"
 
 [node name="SfxSlider" type="HSlider" parent="."]
 offset_left = 337.0
 offset_top = 318.0
 offset_right = 813.0
 offset_bottom = 334.0
-focus_neighbor_top = NodePath("../BackButton/HBoxContainer/LeftKeyButton")
+focus_neighbor_top = NodePath("../BackButton/RemapContainer/LeftMapButton")
 focus_neighbor_bottom = NodePath("../TextureRect/OkayButton")
 focus_next = NodePath("../TextureRect/OkayButton")
-focus_previous = NodePath("../BackButton/HBoxContainer/LeftKeyButton")
+focus_previous = NodePath("../BackButton/RemapContainer/LeftMapButton")
 value = 100.0
 script = ExtResource("2_jtr8r")
 bus_name = "sfx"

--- a/GodotGame/Main Menu Scene/Remapper.gd
+++ b/GodotGame/Main Menu Scene/Remapper.gd
@@ -17,6 +17,9 @@ func _toggled(button_pressed):
 		text = "Waiting for input"
 
 func _unhandled_input(e):
+	if not e is InputEventKey:
+		return
+	
 	if e.pressed:
 		InputMap.action_erase_events(action)
 		InputMap.action_add_event(action, e)

--- a/GodotGame/Main Menu Scene/Remapper.gd
+++ b/GodotGame/Main Menu Scene/Remapper.gd
@@ -1,0 +1,32 @@
+extends Button
+
+@export var action: String
+@onready var remap_container = $"."
+
+func _init():
+	toggle_mode = true
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	set_process_unhandled_input(false)
+
+func _toggled(button_pressed):
+	set_process_unhandled_input(button_pressed)
+	if button_pressed:
+		release_focus()
+		text = "Waiting for input"
+
+func _unhandled_input(e):
+	if e.pressed:
+		InputMap.action_erase_events(action)
+		InputMap.action_add_event(action, e)
+		button_pressed = false
+		grab_focus()
+		update_text()
+
+func update_text():
+	text = " " + InputMap.action_get_events(action)[0].as_text() + " "
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+	#pass

--- a/GodotGame/Main Menu Scene/VolumeOptions.gd
+++ b/GodotGame/Main Menu Scene/VolumeOptions.gd
@@ -1,5 +1,5 @@
 extends HSlider
-@onready var sfx_label = get_node("SFXVolumeValueLabel")
+@onready var vol_label = get_node("SFXVolumeValueLabel")
 var fix_vol_temp = false
 
 @export
@@ -24,4 +24,4 @@ func _on_value_changed(v: float) -> void:
 		linear_to_db(v / 100)
 	)
 	
-	sfx_label.text = str(v) + "%"
+	vol_label.text = str(v) + "%"


### PR DESCRIPTION
Remapping keys in the option menu now work (it was previously a work in progress) which completes #20.

Added to options menu:
- Added second slider for music.
- Key shortcuts now work.

Known issues have been fixed:
- Back button can be selected where there's no back button.
- Crash when changing keys.
- Main menu grab_focus has been fixed (the one thing that isn't related to options menu in this PR).

Future possible improvements:
- Reset keys.
- Label for keys.

Ready to merge now or after if someone else prefers to push their PR first.

<details>
<summary>Screenshot</summary>

![image](https://github.com/FrancisTR/Godot-Purified/assets/57016218/1c539d39-94e7-474b-b6f2-2587ea9fd606)


</details>