### PR TITLE
Options menu: Duplicate keys can no longer be mapped together

### DIFF
--- a/GodotGame/Main Menu Scene/Menu_Scripts/Remapper.gd
+++ b/GodotGame/Main Menu Scene/Menu_Scripts/Remapper.gd
@@ -3,7 +3,9 @@ extends Button
 #TODO: Make user change the button one at a time
 
 @export var action: String
-@onready var remap_container = $"."
+#@onready var button = $"."
+@onready var remap_container = $".."
+
 #var not_waiting_input = false
 
 func _init():
@@ -14,39 +16,75 @@ func _ready():
 	set_process_unhandled_input(false)
 	update_text()
 	$HintLabel.text = action
+	#actions.append(action)
 
 func _toggled(button_pressed):
 	set_process_unhandled_input(button_pressed)
 	if button_pressed:
 		release_focus()
 		text = "???"
-		
-
 
 func _unhandled_input(e):
 	if not e is InputEventKey:
 		return
 	
 	if e.pressed:
-		InputMap.action_erase_events(action)
-		InputMap.action_add_event(action, e)
-		button_pressed = false
+		for k in get_all_keymaps():
+			#print(k)
+			#print(e)
+			#print("---")
+			if e.keycode == k.keycode:
+				# Move below message to in game
+				button_pressed = false
+				break
+		
+		if button_pressed:
+			button_pressed = false
+			InputMap.action_erase_events(action)
+			InputMap.action_add_event(action, e)
+		else:
+			print("Key is already used. Not setting new key.")
+
 		grab_focus()
 		update_text()
 
 func update_text():
-	var tmp = InputMap.action_get_events(action)[0].as_text()
+	text = get_keymap_name(action)
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+	#pass
+
+func get_all_keymaps() -> Array[InputEventKey]:
+	var children = remap_container.get_children()
+	var arr: Array[InputEventKey]
+	for child in children:
+		# below = wrong function. should get InputEvent instead of action or name
+		#arr.append(get_keymap_name(child.action))
+		arr.append(InputMap.action_get_events(child.action)[0])
+		
+		
+	print("size=" + str(children.size())) #is_empty
+	return arr
+	
+	
+func get_all_actions() -> Array[String]:
+	var children = remap_container.get_children()
+	var arr: Array[String]
+	for child in children:
+		arr.append(child.action)
+		
+	return arr
+
+func get_keymap_name(action_name: String) -> String:
+	var tmp = InputMap.action_get_events(action_name)[0].as_text()
 	tmp = tmp.split(" ")
 	var text_tmp: String
 	#if tmp[-1] == "(Physical)":
 	for word in tmp:
-		print(word)
+		#print(word)
 		if word != "(Physical)":
 			text_tmp = text_tmp + word
 		else:
 			text_tmp = text_tmp + "*"
 			
-	text = " " + text_tmp + " "
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-	#pass
+	return " " + text_tmp + " "

--- a/GodotGame/Main Menu Scene/Options.tscn
+++ b/GodotGame/Main Menu Scene/Options.tscn
@@ -162,9 +162,9 @@ autowrap_mode = 2
 texture_filter = 1
 layout_mode = 2
 offset_left = 800.0
-offset_top = 168.0
+offset_top = 139.0
 offset_right = 903.0
-offset_bottom = 234.0
+offset_bottom = 205.0
 scale = Vector2(1.1, 1.1)
 focus_next = NodePath("../../SfxSlider")
 focus_previous = NodePath("../DownMapButton")
@@ -186,9 +186,9 @@ autowrap_mode = 2
 texture_filter = 1
 layout_mode = 2
 offset_left = 800.0
-offset_top = 87.0
+offset_top = 219.0
 offset_right = 903.0
-offset_bottom = 153.0
+offset_bottom = 285.0
 scale = Vector2(1.1, 1.1)
 focus_next = NodePath("../../SfxSlider")
 focus_previous = NodePath("../DownMapButton")
@@ -198,6 +198,30 @@ script = ExtResource("3_sdtpu")
 action = "Back"
 
 [node name="HintLabel" type="Label" parent="RemapContainer/BackButton"]
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_bottom = 23.0
+grow_horizontal = 2
+text = "..."
+autowrap_mode = 2
+
+[node name="DialogueButton" type="Button" parent="RemapContainer"]
+texture_filter = 1
+layout_mode = 2
+offset_left = 800.0
+offset_top = 59.0
+offset_right = 903.0
+offset_bottom = 125.0
+scale = Vector2(1.1, 1.1)
+focus_next = NodePath("../../SfxSlider")
+focus_previous = NodePath("../DownMapButton")
+theme_override_font_sizes/font_size = 35
+text = "Q"
+script = ExtResource("3_sdtpu")
+action = "StartDialogue"
+
+[node name="HintLabel" type="Label" parent="RemapContainer/DialogueButton"]
 layout_mode = 1
 anchors_preset = 10
 anchor_right = 1.0


### PR DESCRIPTION
### Major addition:

Mappings no longer can be duplicated after setting key maps.

Note: It still lets you pick multiple options, but only one input can be changed at a time.

Note 2: Physical keys and non-physical keys are treated as different keys.
For example: `A*` and `A`. These work different in different keyboard
layouts.


### Minor change:

Added another button to the remaps, since dialogue is now toggled with a key.

Bug: Walking to NPC has a <kbd>Q</kbd> as a hint even when changed.
