### PR TITLE
fix key over NPCs + some notes

### DIFF
--- a/GodotGame/Main Menu Scene/Menu_Scripts/MainMenu.gd
+++ b/GodotGame/Main Menu Scene/Menu_Scripts/MainMenu.gd
@@ -1,4 +1,4 @@
-extends Control # Originally Node2D; probably will conflict
+extends Control
 
 
 ## Called when the node enters the scene tree for the first time.
@@ -58,7 +58,6 @@ func _ready():
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
 	SoundControl.is_playing_theme("main")
-	pass
 
 
 func _on_exit_button_pressed():
@@ -69,6 +68,7 @@ func _on_exit_button_pressed():
 func _on_start_button_pressed():
 	# If first time, go to tutorial
 	SoundControl.is_playing_sound("button")
+	
 	if (GameData.visitTutorial == false):
 		TextTransition.set_to_chained_timed(
 			[

--- a/GodotGame/Main Menu Scene/Menu_Scripts/Options.gd
+++ b/GodotGame/Main Menu Scene/Menu_Scripts/Options.gd
@@ -6,6 +6,7 @@ extends CanvasLayer
 func _ready():
 	#line_edit.grab_focus()
 	$BackButton.grab_focus()
+	
 	if GameData.username != "":
 		$background.texture = load("res://Assets/UISprites/UI_Flat_Slot_01_Unavailable.png")
 	else:

--- a/GodotGame/Main Menu Scene/Menu_Scripts/Remapper.gd
+++ b/GodotGame/Main Menu Scene/Menu_Scripts/Remapper.gd
@@ -79,6 +79,7 @@ func get_all_actions() -> Array[String]:
 
 func get_keymap_name(action_name: String) -> String:
 	var tmp = InputMap.action_get_events(action_name)[0].as_text()
+	
 	tmp = tmp.split(" ")
 	var text_tmp: String
 	#if tmp[-1] == "(Physical)":

--- a/GodotGame/World Scene/World.gd
+++ b/GodotGame/World Scene/World.gd
@@ -34,6 +34,8 @@ func _ready():
 	$UI/Inventory.text = "Inventory\nTwigs: " + str(NumTwigs)
 	#SceneTransition.manual_fade.connect(go_to_next_day)
 	$UI/Day.text = "Day " + str(GameData.day)
+	#$NPCs/PressForDialogue.text = "s"
+	#$NPC/PressForDialogue.text = "s"
 	for i in range(0, len(npcs)):
 		var day = GameData.day
 		if GameData.day > 10:

--- a/GodotGame/World Scene/characters/npc.gd
+++ b/GodotGame/World Scene/characters/npc.gd
@@ -16,7 +16,7 @@ var PressForDialogue_was_opened = false
 func _ready():
 	NPCname = null
 	set_process_input(true)
-	
+	$PressForDialogue.text = InputMap.action_get_events("StartDialogue")[0].as_text()
 	
 func go_pos(delta):
 	if moving:


### PR DESCRIPTION
Changes:
- Cleaner code (very minor).
- Fix key over NPCs not always being correct, noticeable when changing keys.

Other random notes while testing (I will look into fixing some of these):

- "Day x" should be above the inventory UI.
- Music moves to my right side of my ear while on map scene.
- Items come back if i go to options screen (pressing <kbd>Esc</kbd> and going back to game).
- Name should be filled back if changing name.
- "Goodbye" option in dialogue might help to escape the dialogue in some cases where player might be stuck in the dialogue and already heard everything. 
- Player is visible above trees (maybe applies to other things) in main world. Doesn't apply to wilderness. Could be related to not being able to select trees in newer versions of the code.
- Congrats on three days being playable now :tada: