### PR TITLE
Fixed Day 8 Soft-Lock Bug

### DIFF
--- a/GodotGame/World Scene/UIs/crafting_table.gd
+++ b/GodotGame/World Scene/UIs/crafting_table.gd
@@ -126,7 +126,7 @@ func _process(delta):
 		$UI/CraftingList/CraftButton.visible = false
 	
 	if GameData.day == 8:
-		if GameData.day_8_count >= 2 and str(get_tree().current_scene.scene_file_path) == "res://World Scene/Wilderness.tscn":
+		if GameData.day_8_count >= 2 and CTtype != "Well":
 			$UI/CraftingList/CraftButton.visible = false
 		else:
 			$UI/CraftingList/CraftButton.visible = true

--- a/GodotGame/World Scene/UIs/crafting_table.gd
+++ b/GodotGame/World Scene/UIs/crafting_table.gd
@@ -69,6 +69,7 @@ func _process(delta):
 	#Crafting table or Well Crafting
 	if GameData.day == 8 and CTtype != "Well" and GameData.day_8_count < 2:
 		craftingList = {"WaterBottle": 1, "Sand": 2, "Rock": 2, "Moss": 2}
+		craftingList = {} #delete
 		listKeys = craftingList.keys()
 		listValues = craftingList.values()
 		ItemOfTheDay = "WaterFilter"
@@ -77,6 +78,7 @@ func _process(delta):
 	if GameData.day == 8 and CTtype == "Well":
 		#Well Recipe
 		craftingList = {"Twig": 5, "Rock": 5}
+		craftingList = {} #delete
 		listKeys = craftingList.keys()
 		listValues = craftingList.values()
 		ItemOfTheDay = "Well"
@@ -125,8 +127,12 @@ func _process(delta):
 	else:
 		$UI/CraftingList/CraftButton.visible = false
 		
-	if GameData.day_8_count >= 2:
+	#print(get_tree().current_scene.scene_file_path, " bbb ", "res://World Scene/Wilderness.tscn")
+	#print("res://World Scene/Wilderness.tscn"," ... ", str(get_tree().current_scene.scene_file_path) == "res://World Scene/Wilderness.tscn")
+	if GameData.day_8_count >= 2 and str(get_tree().current_scene.scene_file_path) == "res://World Scene/Wilderness.tscn":
 		$UI/CraftingList/CraftButton.visible = false
+	else:
+		$UI/CraftingList/CraftButton.visible = true
 		
 	if Input.is_action_just_pressed("Interaction") and enterBody == true:	
 		#if (self.name == "CraftingTablePRIME"):

--- a/GodotGame/World Scene/UIs/crafting_table.gd
+++ b/GodotGame/World Scene/UIs/crafting_table.gd
@@ -125,10 +125,11 @@ func _process(delta):
 	else:
 		$UI/CraftingList/CraftButton.visible = false
 	
-	if GameData.day_8_count >= 2 and str(get_tree().current_scene.scene_file_path) == "res://World Scene/Wilderness.tscn":
-		$UI/CraftingList/CraftButton.visible = false
-	else:
-		$UI/CraftingList/CraftButton.visible = true
+	if GameData.day == 8:
+		if GameData.day_8_count >= 2 and str(get_tree().current_scene.scene_file_path) == "res://World Scene/Wilderness.tscn":
+			$UI/CraftingList/CraftButton.visible = false
+		else:
+			$UI/CraftingList/CraftButton.visible = true
 		
 	if Input.is_action_just_pressed("Interaction") and enterBody == true:	
 		#if (self.name == "CraftingTablePRIME"):

--- a/GodotGame/World Scene/UIs/crafting_table.gd
+++ b/GodotGame/World Scene/UIs/crafting_table.gd
@@ -69,7 +69,6 @@ func _process(delta):
 	#Crafting table or Well Crafting
 	if GameData.day == 8 and CTtype != "Well" and GameData.day_8_count < 2:
 		craftingList = {"WaterBottle": 1, "Sand": 2, "Rock": 2, "Moss": 2}
-		craftingList = {} #delete
 		listKeys = craftingList.keys()
 		listValues = craftingList.values()
 		ItemOfTheDay = "WaterFilter"
@@ -78,7 +77,6 @@ func _process(delta):
 	if GameData.day == 8 and CTtype == "Well":
 		#Well Recipe
 		craftingList = {"Twig": 5, "Rock": 5}
-		craftingList = {} #delete
 		listKeys = craftingList.keys()
 		listValues = craftingList.values()
 		ItemOfTheDay = "Well"
@@ -126,9 +124,7 @@ func _process(delta):
 				listTextImg[i].texture = load("res://Assets/Custom/Items/Moss.png")
 	else:
 		$UI/CraftingList/CraftButton.visible = false
-		
-	#print(get_tree().current_scene.scene_file_path, " bbb ", "res://World Scene/Wilderness.tscn")
-	#print("res://World Scene/Wilderness.tscn"," ... ", str(get_tree().current_scene.scene_file_path) == "res://World Scene/Wilderness.tscn")
+	
 	if GameData.day_8_count >= 2 and str(get_tree().current_scene.scene_file_path) == "res://World Scene/Wilderness.tscn":
 		$UI/CraftingList/CraftButton.visible = false
 	else:


### PR DESCRIPTION
Previous Problem:
After you craft the 2 filters on day 8, the crafting button is supposed to be hidden, but because the well is a re-textured crafting table the button was also hidden when looking at the well. Meaning you can't finish the game past day 8.

The Fix:
Added to the if-condition that's responsible. Now it also checks if the current scene is the wilderness. If not, the turn them visible again.
Also put it in another condition that just checks if the current day is day 8, just in case.

Summary: Crafting two filters in the wilderness before fixing the well will make the well impossible to fix making the game unplayable. Fixed it by editing the if-condition.
