### PR TITLE
Remap fixes

### DIFF
--- a/GodotGame/Globals/Global_Scripts/RemapperData.gd
+++ b/GodotGame/Globals/Global_Scripts/RemapperData.gd
@@ -1,0 +1,17 @@
+extends Node
+
+# Related: ../../Main\ Menu\ Scene/Menu_Scripts/Remapper.gd 
+func get_keymap_name(action_name: String) -> String:
+	InputMap.action_get_events(action_name)[0]
+	var input_map_key = InputMap.action_get_events(action_name)[0]
+	var physical_keycode: int = input_map_key.physical_keycode
+	var display_keycode: int
+	if physical_keycode == 0:
+		display_keycode = input_map_key.keycode
+	else:
+		display_keycode = DisplayServer.keyboard_get_keycode_from_physical(
+			physical_keycode
+		)
+		
+	#print('string: "%s" keycode: %s' % [OS.get_keycode_string(display_keycode), display_keycode])
+	return " " + OS.get_keycode_string(display_keycode) + " "

--- a/GodotGame/Main Menu Scene/Menu_Scripts/Remapper.gd
+++ b/GodotGame/Main Menu Scene/Menu_Scripts/Remapper.gd
@@ -91,21 +91,29 @@ func get_all_actions() -> Array[String]:
 
 
 
-func get_keymap_name(action_name: String) -> String:
-	var tmp = InputMap.action_get_events(action_name)[0].as_text().split(" ")
+func get_keymap_name(plr_input) -> String: # originally: action_name
+	var tmp
+	if plr_input is InputEventKey: # currently not being used
+		var keycode = DisplayServer.keyboard_get_keycode_from_physical(plr_input.physical_keycode)
+		tmp = OS.get_keycode_string(keycode)
 
-	if tmp.size() > 1:
-		tmp = tmp[0]
+	elif plr_input is String:
+		var keycode = DisplayServer.keyboard_get_keycode_from_physical(
+			InputMap.action_get_events(plr_input)[0].physical_keycode
+		)
+		tmp = OS.get_keycode_string(keycode)
+
 	else:
-		tmp = tmp[0] + "*"
-
+		tmp = str(plr_input)
+		print('KeymapTypeError in get_keymap_name(): ' + tmp + ' must be String or InputEventKey')
+	
 	return " " + tmp + " "
 
 
 
 func toggle_disabled_other_buttons():
-	remap_container.button_in_use = not remap_container.button_in_use
 	var is_disabled = remap_container.button_in_use
+	remap_container.button_in_use = not is_disabled
 	
 	$"../../BackButton".disabled = is_disabled
 	if GameData.visitTutorial == false:

--- a/GodotGame/Main Menu Scene/Menu_Scripts/Remapper.gd
+++ b/GodotGame/Main Menu Scene/Menu_Scripts/Remapper.gd
@@ -1,4 +1,5 @@
 extends Button
+# todo: ideally, key changes should only take effect after saving changes
 
 @export var action: String
 #@onready var button = $"."
@@ -90,30 +91,24 @@ func get_all_actions() -> Array[String]:
 	return arr
 
 
-
-func get_keymap_name(plr_input) -> String: # originally: action_name
-	var tmp
-	if plr_input is InputEventKey: # currently not being used
-		var keycode = DisplayServer.keyboard_get_keycode_from_physical(plr_input.physical_keycode)
-		tmp = OS.get_keycode_string(keycode)
-
-	elif plr_input is String:
-		var keycode = DisplayServer.keyboard_get_keycode_from_physical(
-			InputMap.action_get_events(plr_input)[0].physical_keycode
-		)
-		tmp = OS.get_keycode_string(keycode)
-
+func get_keymap_name(action_name: String) -> String:
+	var input_map_key = InputMap.action_get_events(action_name)[0]
+	var physical_keycode: int = input_map_key.physical_keycode
+	var display_keycode: int
+	if physical_keycode == 0:
+		display_keycode = input_map_key.keycode
 	else:
-		tmp = str(plr_input)
-		print('KeymapTypeError in get_keymap_name(): ' + tmp + ' must be String or InputEventKey')
-	
-	return " " + tmp + " "
-
+		display_keycode = DisplayServer.keyboard_get_keycode_from_physical(
+			physical_keycode
+		)
+		
+	#print('string: "%s" keycode: %s' % [OS.get_keycode_string(display_keycode), display_keycode])
+	return " " + OS.get_keycode_string(display_keycode) + " "
 
 
 func toggle_disabled_other_buttons():
-	var is_disabled = remap_container.button_in_use
-	remap_container.button_in_use = not is_disabled
+	var is_disabled = not remap_container.button_in_use
+	remap_container.button_in_use = is_disabled
 	
 	$"../../BackButton".disabled = is_disabled
 	if GameData.visitTutorial == false:

--- a/GodotGame/Main Menu Scene/Menu_Scripts/Remapper.gd
+++ b/GodotGame/Main Menu Scene/Menu_Scripts/Remapper.gd
@@ -65,10 +65,8 @@ func _unhandled_input(e):
 
 
 func update_text():
-	text = get_keymap_name(action)
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-	#pass
+	text = RemapperData.get_keymap_name(action)
+
 
 func get_all_keymaps() -> Array[InputEventKey]:
 	var arr: Array[InputEventKey]
@@ -89,21 +87,6 @@ func get_all_actions() -> Array[String]:
 		arr.append(child.action)
 
 	return arr
-
-
-func get_keymap_name(action_name: String) -> String:
-	var input_map_key = InputMap.action_get_events(action_name)[0]
-	var physical_keycode: int = input_map_key.physical_keycode
-	var display_keycode: int
-	if physical_keycode == 0:
-		display_keycode = input_map_key.keycode
-	else:
-		display_keycode = DisplayServer.keyboard_get_keycode_from_physical(
-			physical_keycode
-		)
-		
-	#print('string: "%s" keycode: %s' % [OS.get_keycode_string(display_keycode), display_keycode])
-	return " " + OS.get_keycode_string(display_keycode) + " "
 
 
 func toggle_disabled_other_buttons():

--- a/GodotGame/World Scene/Controls.gd
+++ b/GodotGame/World Scene/Controls.gd
@@ -3,14 +3,14 @@ extends CanvasLayer
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	$Top/Label.text = InputMap.action_get_events("Up")[0].as_text().replace("(Physical)", "").strip_edges(true, true)
-	$Left/Label.text = InputMap.action_get_events("Left")[0].as_text().replace("(Physical)", "").strip_edges(true, true)
-	$Mid/Label.text = InputMap.action_get_events("Down")[0].as_text().replace("(Physical)", "").strip_edges(true, true)
-	$Right/Label.text = InputMap.action_get_events("Right")[0].as_text().replace("(Physical)", "").strip_edges(true, true)
-	$Sprint/Label.text = InputMap.action_get_events("Sprint")[0].as_text().replace("(Physical)", "").strip_edges(true, true)
+	$Top/Label.text = RemapperData.get_keymap_name("Up")
+	$Left/Label.text = RemapperData.get_keymap_name("Left")
+	$Mid/Label.text = RemapperData.get_keymap_name("Down")
+	$Right/Label.text = RemapperData.get_keymap_name("Right")
+	$Sprint/Label.text = RemapperData.get_keymap_name("Sprint")
 	
-	$Map/Label.text = InputMap.action_get_events("Map")[0].as_text().replace("(Physical)", "").strip_edges(true, true)
-	$Inventory/Label.text = InputMap.action_get_events("Inventory")[0].as_text().replace("(Physical)", "").strip_edges(true, true)
+	$Map/Label.text = RemapperData.get_keymap_name("Map")
+	$Inventory/Label.text = RemapperData.get_keymap_name("Inventory")
 
 
 func _process(delta):

--- a/GodotGame/World Scene/UIs/crafting_table.gd
+++ b/GodotGame/World Scene/UIs/crafting_table.gd
@@ -29,7 +29,7 @@ var listValues
 
 
 func _ready():
-	$PressInteraction.text = InputMap.action_get_events("Interaction")[0].as_text().replace("(Physical)", "").strip_edges(true, true)
+	$PressInteraction.text = RemapperData.get_keymap_name("Interaction")
 	$UI/CraftingList.visible = false
 	
 	#Well is fixed after day 8

--- a/GodotGame/World Scene/characters/Kidsnpc.gd
+++ b/GodotGame/World Scene/characters/Kidsnpc.gd
@@ -13,7 +13,7 @@ var PressForDialogue_was_opened = false
 func _ready():
 	NPCname = null
 	set_process_input(true)
-	$PressForDialogue.text = InputMap.action_get_events("Interaction")[0].as_text()
+	$PressForDialogue.text = RemapperData.get_keymap_name("Interaction")
 	if (GameData.day == 3):
 		$Sprite2D.animation = "Day3Sad"
 

--- a/GodotGame/World Scene/characters/npc.gd
+++ b/GodotGame/World Scene/characters/npc.gd
@@ -1140,7 +1140,7 @@ var audioCount = -1
 func _ready():
 	NPCname = null
 	set_process_input(true)
-	$PressForDialogue.text = InputMap.action_get_events("Interaction")[0].as_text().replace("(Physical)", "").strip_edges(true, true)
+	$PressForDialogue.text = RemapperData.get_keymap_name("Interaction")
 	if GameData.day == 3:
 		if $"../Bargin/Sprite2D" != null:
 			$"../Bargin/Sprite2D".animation = "Barry_Sad"

--- a/GodotGame/project.godot
+++ b/GodotGame/project.godot
@@ -23,6 +23,7 @@ TextTransition="*res://Globals/Global_Scripts/text_transition.gd"
 TextTransitionData="*res://Globals/Global_Scripts/TextTransitionData.gd"
 Utils="*res://Globals/Global_Scripts/Util/Utils.gd"
 SoundControl="*res://Globals/sound_control.tscn"
+RemapperData="*res://Globals/Global_Scripts/RemapperData.gd"
 
 [display]
 

--- a/GodotGame/project.godot
+++ b/GodotGame/project.godot
@@ -75,7 +75,7 @@ Inventory={
 }
 Back={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194305,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 Interaction={
@@ -90,7 +90,7 @@ Map={
 }
 Sprint={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194325,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 


### PR DESCRIPTION
- Escape and shift can be used regardless of position. (For example, if you have caps lock mapped to escape, you can use both physical keys now; this wasn't the case before.)
- All remaps show correct labels in Options settings menu regardless of if physical keys (position of where you keys are in the keyboard) are different than what the keys actually are in your keyboard layout. Especially useful if someone has a keyboard set to a different language with AZERTY layout and such.
- Tested code.
- Cleaner code relating to remaps.
- Removed asterisk `*` for now; since they represent physical keys, not something the user needs to know. In the future, they could represent changed keys in general or unsaved changes.

<details>
<summary>Screenshots</summary>

With this layout ([Dvorak](https://en.wikipedia.org/wiki/Dvorak_Simplified_Keyboard)):
![With this layout](https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/KB_United_States_Dvorak.svg/1200px-KB_United_States_Dvorak.svg.png)

It automatically shows up like this in the game, which are much better defaults:
![It shows up like this in the game, no changes](https://github.com/FrancisTR/Godot-Purified/assets/57016218/8349cf4e-6a72-4e65-8e74-b4de33af0b01)

</details>